### PR TITLE
Implement bracket creation functionality

### DIFF
--- a/NikoBracket.xcodeproj/project.pbxproj
+++ b/NikoBracket.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		158449B9F010F7B81BBE6CAE /* Pods_NikoBracket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AB6547BC4AA7125ECBD228 /* Pods_NikoBracket.framework */; };
-		437309362892013C00323DCE /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 437309352892013C00323DCE /* Keys.plist */; };
+		4324E00D2898534400EFC8C4 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4324E00C2898534400EFC8C4 /* Keys.plist */; };
 		43D3078D2890ABA3001573F0 /* CreateBracketViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D3078C2890ABA3001573F0 /* CreateBracketViewController.m */; };
 		43D307902890ADDD001573F0 /* CreateBracketViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D3078F2890ADDD001573F0 /* CreateBracketViewCell.m */; };
 		43DA21F1287F8E0000457AC4 /* HomeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 43DA21F0287F8E0000457AC4 /* HomeViewController.m */; };
@@ -55,7 +55,7 @@
 		2B63A441EB2844F59AFC5797 /* Pods-NikoBracket.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NikoBracket.debug.xcconfig"; path = "Target Support Files/Pods-NikoBracket/Pods-NikoBracket.debug.xcconfig"; sourceTree = "<group>"; };
 		2C149748E6F469F6F4E158C2 /* Pods_NikoBracketTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NikoBracketTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C25FB1B6E0BB80ED29971A3 /* Pods-NikoBracketTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NikoBracketTests.release.xcconfig"; path = "Target Support Files/Pods-NikoBracketTests/Pods-NikoBracketTests.release.xcconfig"; sourceTree = "<group>"; };
-		437309352892013C00323DCE /* Keys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Keys.plist; sourceTree = "<group>"; };
+		4324E00C2898534400EFC8C4 /* Keys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Keys.plist; sourceTree = "<group>"; };
 		43D3078B2890ABA3001573F0 /* CreateBracketViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CreateBracketViewController.h; sourceTree = "<group>"; };
 		43D3078C2890ABA3001573F0 /* CreateBracketViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CreateBracketViewController.m; sourceTree = "<group>"; };
 		43D3078E2890ADDD001573F0 /* CreateBracketViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CreateBracketViewCell.h; sourceTree = "<group>"; };
@@ -197,7 +197,7 @@
 				43D3078C2890ABA3001573F0 /* CreateBracketViewController.m */,
 				43D3078E2890ADDD001573F0 /* CreateBracketViewCell.h */,
 				43D3078F2890ADDD001573F0 /* CreateBracketViewCell.m */,
-				437309352892013C00323DCE /* Keys.plist */,
+				4324E00C2898534400EFC8C4 /* Keys.plist */,
 			);
 			path = NikoBracket;
 			sourceTree = "<group>";
@@ -344,7 +344,7 @@
 				43FCF36A287DFC5900B30CC0 /* LaunchScreen.storyboard in Resources */,
 				43FCF367287DFC5900B30CC0 /* Assets.xcassets in Resources */,
 				43FCF365287DFC5800B30CC0 /* Main.storyboard in Resources */,
-				437309362892013C00323DCE /* Keys.plist in Resources */,
+				4324E00D2898534400EFC8C4 /* Keys.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NikoBracket.xcodeproj/project.pbxproj
+++ b/NikoBracket.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		158449B9F010F7B81BBE6CAE /* Pods_NikoBracket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AB6547BC4AA7125ECBD228 /* Pods_NikoBracket.framework */; };
-		4324E00D2898534400EFC8C4 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4324E00C2898534400EFC8C4 /* Keys.plist */; };
+		4324E00F28999C3D00EFC8C4 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4324E00E28999C3D00EFC8C4 /* Keys.plist */; };
 		43D3078D2890ABA3001573F0 /* CreateBracketViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D3078C2890ABA3001573F0 /* CreateBracketViewController.m */; };
 		43D307902890ADDD001573F0 /* CreateBracketViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D3078F2890ADDD001573F0 /* CreateBracketViewCell.m */; };
 		43DA21F1287F8E0000457AC4 /* HomeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 43DA21F0287F8E0000457AC4 /* HomeViewController.m */; };
@@ -55,7 +55,7 @@
 		2B63A441EB2844F59AFC5797 /* Pods-NikoBracket.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NikoBracket.debug.xcconfig"; path = "Target Support Files/Pods-NikoBracket/Pods-NikoBracket.debug.xcconfig"; sourceTree = "<group>"; };
 		2C149748E6F469F6F4E158C2 /* Pods_NikoBracketTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NikoBracketTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C25FB1B6E0BB80ED29971A3 /* Pods-NikoBracketTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NikoBracketTests.release.xcconfig"; path = "Target Support Files/Pods-NikoBracketTests/Pods-NikoBracketTests.release.xcconfig"; sourceTree = "<group>"; };
-		4324E00C2898534400EFC8C4 /* Keys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Keys.plist; sourceTree = "<group>"; };
+		4324E00E28999C3D00EFC8C4 /* Keys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Keys.plist; path = ../../Keys.plist; sourceTree = "<group>"; };
 		43D3078B2890ABA3001573F0 /* CreateBracketViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CreateBracketViewController.h; sourceTree = "<group>"; };
 		43D3078C2890ABA3001573F0 /* CreateBracketViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CreateBracketViewController.m; sourceTree = "<group>"; };
 		43D3078E2890ADDD001573F0 /* CreateBracketViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CreateBracketViewCell.h; sourceTree = "<group>"; };
@@ -197,7 +197,7 @@
 				43D3078C2890ABA3001573F0 /* CreateBracketViewController.m */,
 				43D3078E2890ADDD001573F0 /* CreateBracketViewCell.h */,
 				43D3078F2890ADDD001573F0 /* CreateBracketViewCell.m */,
-				4324E00C2898534400EFC8C4 /* Keys.plist */,
+				4324E00E28999C3D00EFC8C4 /* Keys.plist */,
 			);
 			path = NikoBracket;
 			sourceTree = "<group>";
@@ -340,11 +340,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4324E00F28999C3D00EFC8C4 /* Keys.plist in Resources */,
 				43F2785F2889F8D3007E15E6 /* teams.json in Resources */,
 				43FCF36A287DFC5900B30CC0 /* LaunchScreen.storyboard in Resources */,
 				43FCF367287DFC5900B30CC0 /* Assets.xcassets in Resources */,
 				43FCF365287DFC5800B30CC0 /* Main.storyboard in Resources */,
-				4324E00D2898534400EFC8C4 /* Keys.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NikoBracket/Base.lproj/Main.storyboard
+++ b/NikoBracket/Base.lproj/Main.storyboard
@@ -163,7 +163,16 @@
                         <viewLayoutGuide key="safeArea" id="Ye7-Xa-P0x"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" id="sMC-bH-KoS"/>
+                    <navigationItem key="navigationItem" id="sMC-bH-KoS">
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="jOh-dA-Vjp">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="ZdN-rs-0e0">
+                                <rect key="frame" x="302" y="5" width="92" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="gray" image="info.circle" catalog="system"/>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="infoTableView" destination="VnR-zB-1Rx" id="yeS-tT-wcj"/>
                     </connections>
@@ -293,7 +302,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="uuQ-b5-KQ8">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
@@ -305,7 +314,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ILX-Y8-XRX">
-                                                    <rect key="frame" x="20" y="98" width="374" height="32"/>
+                                                    <rect key="frame" x="20" y="104" width="374" height="32"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <segments>
                                                         <segment title="Away"/>
@@ -319,38 +328,38 @@
                                                     <rect key="frame" x="273" y="0.0" width="46" height="46"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dLs-jr-kRW">
+                                                    <rect key="frame" x="205" y="53" width="189" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBI-U4-8EP">
+                                                    <rect key="frame" x="20" y="53" width="180" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Px1-p0-LKB">
+                                                    <rect key="frame" x="20" y="75" width="180" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mNi-8n-vSn">
+                                                    <rect key="frame" x="205" y="75" width="189" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Si-v3-t2o">
-                                                    <rect key="frame" x="68" y="0.0" width="46" height="46"/>
+                                                    <rect key="frame" x="87" y="0.0" width="46" height="46"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dLs-jr-kRW">
-                                                    <rect key="frame" x="277" y="53" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBI-U4-8EP">
-                                                    <rect key="frame" x="70" y="53" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Px1-p0-LKB">
-                                                    <rect key="frame" x="70" y="75" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mNi-8n-vSn">
-                                                    <rect key="frame" x="277" y="75" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
@@ -369,9 +378,27 @@
                         <viewLayoutGuide key="safeArea" id="TQZ-cd-fcF"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" id="tJI-mS-jQJ"/>
+                    <navigationItem key="navigationItem" id="tJI-mS-jQJ">
+                        <nil key="title"/>
+                        <segmentedControl key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="MjZ-AA-vO4">
+                            <rect key="frame" x="50" y="5.5" width="352" height="33"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <segments>
+                                <segment title="1st"/>
+                                <segment title="2nd"/>
+                                <segment title="Sweet 16"/>
+                                <segment title="Elite 8"/>
+                                <segment title="Final 4"/>
+                                <segment title="CHIP"/>
+                            </segments>
+                            <connections>
+                                <action selector="roundSelectAction:" destination="yLW-Xc-dMQ" eventType="valueChanged" id="TAT-Li-izN"/>
+                            </connections>
+                        </segmentedControl>
+                    </navigationItem>
                     <connections>
                         <outlet property="createBracketTableView" destination="uuQ-b5-KQ8" id="zYT-f7-Eiv"/>
+                        <outlet property="roundControl" destination="MjZ-AA-vO4" id="adE-ny-9hm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Urx-EU-B25" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -609,6 +636,7 @@
     </scenes>
     <resources>
         <image name="house" catalog="system" width="128" height="106"/>
+        <image name="info.circle" catalog="system" width="128" height="121"/>
         <image name="logo.playstation" catalog="system" width="128" height="92"/>
         <image name="logo.xbox" catalog="system" width="128" height="121"/>
         <image name="newspaper" catalog="system" width="128" height="111"/>

--- a/NikoBracket/CreateBracketViewCell.h
+++ b/NikoBracket/CreateBracketViewCell.h
@@ -5,6 +5,8 @@
 //  Created by Nikolas Georgaklis on 7/26/22.
 //
 
+
+#import "CreateBracketViewController.h"
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -18,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UILabel *awayFavorite;
 @property (weak, nonatomic) IBOutlet UILabel *awayTeamName;
 @property long indexPath;
+@property (strong, nonatomic) CreateBracketViewController *createBracketView;
+@property long section;
 
 @end
 

--- a/NikoBracket/CreateBracketViewCell.m
+++ b/NikoBracket/CreateBracketViewCell.m
@@ -6,6 +6,8 @@
 //
 
 #import "CreateBracketViewCell.h"
+#import "CreateBracketViewController.h"
+
 
 @implementation CreateBracketViewCell
 
@@ -22,10 +24,10 @@
     
 }
 - (IBAction)teamSelectAction:(id)sender {
-    NSLog(self.teamSelect.selectedSegmentIndex ? @"true" : @"false");
-    NSLog(@"%d", self.indexPath);
-    
+    [self.createBracketView changePick:self.indexPath inSection:self.section inCell:self];
 }
+
+
 
 
 @end

--- a/NikoBracket/CreateBracketViewController.h
+++ b/NikoBracket/CreateBracketViewController.h
@@ -6,11 +6,12 @@
 //
 
 #import <UIKit/UIKit.h>
-
+#import "CreateBracketViewCell.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CreateBracketViewController : UIViewController
 
+- (void)changePick:(int) index inSection:(int) section inCell:(UITableViewCell *) cell;
 
 
 @end

--- a/NikoBracket/CreateBracketViewController.m
+++ b/NikoBracket/CreateBracketViewController.m
@@ -9,6 +9,12 @@
 #import "Parse/Parse.h"
 #import "UIImageView+AFNetworking.h"
 static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/scores/json/Tournament/2022?key=";
+static const NSInteger kRound1 = 0;
+static const NSInteger kRound2 = 1;
+static const NSInteger kRound3 = 2;
+static const NSInteger kRound4 = 3;
+static const NSInteger kSemiFinal = 4;
+static const NSInteger kFinal = 5;
 
 @interface CreateBracketViewController () <UITableViewDelegate, UITableViewDataSource>
 
@@ -224,34 +230,34 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
 
 
     switch (self.roundControl.selectedSegmentIndex) {
-        case 0:
+        case kRound1:
             currentWestMatchups = self.westMatchups;
             currentSouthMatchups = self.southMatchups;
             currentEastMatchups = self.eastMatchups;
             currentMidwestMatchups = self.midwestMatchups;
             break;
-        case 1:
+        case kRound2:
             currentWestMatchups = self.westPicks[1];
             currentSouthMatchups = self.southPicks[1];
             currentEastMatchups = self.eastPicks[1];
             currentMidwestMatchups = self.midwestPicks[1];
             break;
-        case 2:
+        case kRound3:
             currentWestMatchups = self.westPicks[2];
             currentSouthMatchups = self.southPicks[2];
             currentEastMatchups = self.eastPicks[2];
             currentMidwestMatchups = self.midwestPicks[2];
             break;
-        case 3:
+        case kRound4:
             currentWestMatchups = self.westPicks[3];
             currentSouthMatchups = self.southPicks[3];
             currentEastMatchups = self.eastPicks[3];
             currentMidwestMatchups = self.midwestPicks[3];
             break;
-        case 4:
+        case kSemiFinal:
             semisMatchups = self.finalsPicks[0];
             break;
-        case 5:
+        case kFinal:
             championship = self.finalsPicks[1];
             break;
         default:
@@ -350,22 +356,22 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
    
     switch (self.roundControl.selectedSegmentIndex) {
-        case 0:
+        case kRound1:
             return 8;
             break;
-        case 1:
+        case kRound2:
             return 4;
             break;
-        case 2:
+        case kRound3:
             return 2;
             break;
-        case 3:
+        case kRound4:
             return 1;
             break;
-        case 4:
+        case kSemiFinal:
             return 2;
             break;
-        default:
+        case kFinal:
             return 1;
             break;
     }
@@ -427,6 +433,7 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
     NSMutableArray *round4 = [[NSMutableArray alloc] init];
     
     for (int i = 0; i < round1.count - 1; i+=2) {
+        //each "game" object contains 3 elements: two 3-5 letter abbreviations, one for the home team, one for the away team, and the third element is a 0 or 1 indicating the user’s choice for who they believe will win the game
         NSArray *game = round1[i];
         NSArray *game2 = round1[i+1];
 
@@ -476,12 +483,32 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
         }
     }
     
-    matchups[1] = round2;
-    matchups[2] = round3;
-    matchups[3] = round4;
+    switch (matchups.count) {
+        case 0:
+            [matchups addObject:round2];
+            [matchups addObject:round3];
+            [matchups addObject:round4];
+            break;
+        case 1:
+            matchups[1] = round2;
+            [matchups addObject:round3];
+            [matchups addObject:round4];
+            break;
+        case 2:
+            matchups[1] = round2;
+            matchups[2] = round3;
+            [matchups addObject:round4];
+            break;
+        default:
+            matchups[1] = round2;
+            matchups[2] = round3;
+            matchups[3] = round4;
+            break;
+    }
     
     return matchups;
 }
+
 - (NSMutableArray *) initializeUserFinalsBracket:(NSMutableArray *) finalsMatchups {
     NSMutableArray *final_4 = [[NSMutableArray alloc] init];
     NSMutableArray *championship = [[NSMutableArray alloc] init];
@@ -519,7 +546,12 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
     }
     
     //add final4 to finals matchups
-    finalsMatchups[0] = final_4;
+    if (finalsMatchups.count > 0) {
+        finalsMatchups[0] = final_4;
+    }
+    else {
+        [finalsMatchups addObject:final_4];
+    }
     
     //championship
     NSArray *semisGame1 = final_4[0];
@@ -537,7 +569,13 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
         [championship addObject:finalMatchup];
     }
     
-    finalsMatchups[1] = championship;
+    //add championship to finals matchups
+    if (finalsMatchups.count == 2) {
+        finalsMatchups[1] = championship;
+    }
+    else {
+        [finalsMatchups addObject:championship];
+    }
 
     return finalsMatchups;
 }

--- a/NikoBracket/CreateBracketViewController.m
+++ b/NikoBracket/CreateBracketViewController.m
@@ -6,11 +6,13 @@
 //
 #import "CreateBracketViewCell.h"
 #import "CreateBracketViewController.h"
+#import "Parse/Parse.h"
 #import "UIImageView+AFNetworking.h"
 static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/scores/json/Tournament/2022?key=";
 
 @interface CreateBracketViewController () <UITableViewDelegate, UITableViewDataSource>
 
+@property (strong, nonatomic) PFUser *user;
 @property(strong, nonatomic) NSMutableArray *arrayOfMatchups;
 @property (weak, nonatomic) IBOutlet UITableView *createBracketTableView;
 @property (strong, nonatomic) UIRefreshControl *refreshControl;
@@ -20,6 +22,15 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
 @property (strong, nonatomic) NSMutableArray *eastMatchups;
 @property (strong, nonatomic) NSMutableArray *midwestMatchups;
 @property (strong, nonatomic) NSMutableArray *southMatchups;
+@property (strong, nonatomic) NSMutableArray *westPicks;
+@property (strong, nonatomic) NSMutableArray *southPicks;
+@property (strong, nonatomic) NSMutableArray *eastPicks;
+@property (strong, nonatomic) NSMutableArray *midwestPicks;
+@property (strong, nonatomic) NSMutableArray *finalsPicks;
+@property (weak, nonatomic) IBOutlet UISegmentedControl *roundControl;
+@property int round;
+- (IBAction)roundControlAction:(id)sender;
+
 
 @end
 
@@ -27,7 +38,9 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view.
+    self.user = [PFUser currentUser];
+    self.round = self.roundControl.selectedSegmentIndex;
+    
     self.createBracketTableView.delegate = self;
     self.createBracketTableView.dataSource = self;
     self.createBracketTableView.rowHeight = 150;
@@ -35,6 +48,12 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
     [self.createBracketTableView registerClass:[UITableViewHeaderFooterView class] forHeaderFooterViewReuseIdentifier:@"header"];
     
     [self fetchData];
+    
+    UIFont *font = [UIFont boldSystemFontOfSize:10.0f];
+    NSDictionary *attributes = [NSDictionary dictionaryWithObject:font
+                                                           forKey:NSFontAttributeName];
+    [self.roundControl setTitleTextAttributes:attributes
+                                    forState:UIControlStateNormal];
     
     //Initialize UIRefreshControl
     self.refreshControl = [[UIRefreshControl alloc] init];
@@ -61,87 +80,296 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
     NSError *error;
     NSString *url_string = [NSString stringWithFormat: @"%@%@", kMatchUpsEndpoint, key];
     
+    //read tournament JSON file into tempdictionary
     data = [NSData dataWithContentsOfURL: [NSURL URLWithString:url_string]];
     NSMutableDictionary *tempDictionary = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&error];
+    
+    //create arrays for all first round matchups, also seperate each matchup into regions
     self.matchups = [[NSMutableArray alloc] init];
     self.westMatchups = [[NSMutableArray alloc] init];
     self.eastMatchups = [[NSMutableArray alloc] init];
     self.midwestMatchups = [[NSMutableArray alloc] init];
     self.southMatchups = [[NSMutableArray alloc] init];
 
+    //put all games info into allMatchups
     NSArray *allMatchups = tempDictionary[@"Games"];
     
+    //initialize arrays for first round teams in each region
+    NSMutableArray *round1west = [[NSMutableArray alloc] init];
+    NSMutableArray *round1south = [[NSMutableArray alloc] init];
+    NSMutableArray *round1east = [[NSMutableArray alloc] init];
+    NSMutableArray *round1midwest = [[NSMutableArray alloc] init];
+    
+    //initialize arrays to contain teams from all regions for all rounds
+    self.westPicks = [[NSMutableArray alloc] init];
+    self.southPicks = [[NSMutableArray alloc] init];
+    self.eastPicks = [[NSMutableArray alloc] init];
+    self.midwestPicks = [[NSMutableArray alloc] init];
+
     //isolate 1st round matchups given all matchups
-    for (NSDictionary *game in allMatchups) {
-        if ([game[@"Day"] containsString:@"2022-03-17"]
-            || [game[@"Day"] containsString:@"2022-03-18"]){
+
+    for (int i = 0; i < allMatchups.count; i++) {
+        NSDictionary *game = allMatchups[i];
+        //hardcoded 2022 1st round dates because "round" key returns incorrect data in free API version
+        if ([game[@"Day"] containsString:@"2022-03-17"] || [game[@"Day"] containsString:@"2022-03-18"]){
             [self.matchups addObject:game];
             
             if ([game[@"Bracket"] isEqual:@"West"]) {
                 [self.westMatchups addObject:game];
+
+                NSString *team1 = game[@"AwayTeam"];
+                NSString *team2 = game[@"HomeTeam"];
+                NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:team1, team2, @"0", nil];
+                [round1west addObject:matchup];
             }
             else if ([game[@"Bracket"] isEqual:@"South"]) {
                 [self.southMatchups addObject:game];
+
+                NSString *team1 = game[@"AwayTeam"];
+                NSString *team2 = game[@"HomeTeam"];
+                NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:team1, team2, @"0", nil];
+                [round1south addObject:matchup];
             }
             else if ([game[@"Bracket"] isEqual:@"East"]) {
                 [self.eastMatchups addObject:game];
+
+                NSString *team1 = game[@"AwayTeam"];
+                NSString *team2 = game[@"HomeTeam"];
+                NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:team1, team2, @"0", nil];
+                [round1east addObject:matchup];
             }
             else if ([game[@"Bracket"] isEqual:@"Midwest"]) {
                 [self.midwestMatchups addObject:game];
+
+                NSString *team1 = game[@"AwayTeam"];
+                NSString *team2 = game[@"HomeTeam"];
+                NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:team1, team2, @"0", nil];
+                [round1midwest addObject:matchup];
             }
         }
     }
     
+    [self.westPicks addObject:round1west];
+    [self.southPicks addObject:round1south];
+    [self.eastPicks addObject:round1east];
+    [self.midwestPicks addObject:round1midwest];
+    
+    [self initializeUserBracket:self.westPicks];
+    [self initializeUserBracket:self.southPicks];
+    [self initializeUserBracket:self.eastPicks];
+    [self initializeUserBracket:self.midwestPicks];
+        
+    //finals bracket is different from other brackets, must be set up after regional brackets
+    self.finalsPicks = [[NSMutableArray alloc] init];
+    [self initializeUserFinalsBracket:self.finalsPicks];
+    
+    self.user[@"westPicks"] = self.westPicks;
+    self.user[@"southPicks"] = self.southPicks;
+    self.user[@"eastPicks"] = self.eastPicks;
+    self.user[@"midwestPicks"] = self.midwestPicks;
+    self.user[@"finalsPicks"] = self.finalsPicks;
+
+    
+    [self.user saveInBackgroundWithBlock:^(BOOL succeeded, NSError * _Nullable error) {
     [self.refreshControl endRefreshing];
+    }];
+}
+
+
+- (void) changePick:(int) index inSection:(int) section inCell:(CreateBracketViewCell *) cell{
+    
+    switch (section) {
+        case 0:
+            if (self.roundControl.selectedSegmentIndex < 4) {
+                [self.westPicks[self.roundControl.selectedSegmentIndex][index] replaceObjectAtIndex:2 withObject:(cell.teamSelect.selectedSegmentIndex ? @"1" : @"0")];
+                self.user[@"westPicks"] = self.westPicks;
+            }
+            else{
+                [self.finalsPicks[self.roundControl.selectedSegmentIndex - 4][index] replaceObjectAtIndex:2 withObject:(cell.teamSelect.selectedSegmentIndex ? @"1" : @"0")];
+                self.user[@"finalsPicks"] = self.finalsPicks;
+            }
+            break;
+        case 1:
+            [self.southPicks[self.roundControl.selectedSegmentIndex][index] replaceObjectAtIndex:2 withObject:(cell.teamSelect.selectedSegmentIndex ? @"1" : @"0")];
+            self.user[@"southPicks"] = self.southPicks;
+            
+            break;
+        case 2:
+            [self.eastPicks[self.roundControl.selectedSegmentIndex][index] replaceObjectAtIndex:2 withObject:(cell.teamSelect.selectedSegmentIndex ? @"1" : @"0")];
+            self.user[@"eastPicks"] = self.eastPicks;
+            
+            break;
+        case 3:
+            [self.midwestPicks[self.roundControl.selectedSegmentIndex][index] replaceObjectAtIndex:2 withObject:(cell.teamSelect.selectedSegmentIndex ? @"1" : @"0")];
+            self.user[@"midwestPicks"] = self.midwestPicks;
+            
+            break;
+        default:
+            break;
+    }
+    
+    [self.user saveInBackground];
+    
 }
 
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
     CreateBracketViewCell *createBracketViewCell = [self.createBracketTableView dequeueReusableCellWithIdentifier:@"CreateBracketViewCell"];
     
+    NSMutableArray *currentWestMatchups = [[NSMutableArray alloc] init];
+    NSMutableArray *currentSouthMatchups = [[NSMutableArray alloc] init];
+    NSMutableArray *currentEastMatchups = [[NSMutableArray alloc] init];
+    NSMutableArray *currentMidwestMatchups = [[NSMutableArray alloc] init];
+    NSMutableArray *semisMatchups = [[NSMutableArray alloc] init];
+    NSMutableArray *championship = [[NSMutableArray alloc] init];
+
+
+    switch (self.roundControl.selectedSegmentIndex) {
+        case 0:
+            currentWestMatchups = self.westMatchups;
+            currentSouthMatchups = self.southMatchups;
+            currentEastMatchups = self.eastMatchups;
+            currentMidwestMatchups = self.midwestMatchups;
+            break;
+        case 1:
+            currentWestMatchups = self.westPicks[1];
+            currentSouthMatchups = self.southPicks[1];
+            currentEastMatchups = self.eastPicks[1];
+            currentMidwestMatchups = self.midwestPicks[1];
+            break;
+        case 2:
+            currentWestMatchups = self.westPicks[2];
+            currentSouthMatchups = self.southPicks[2];
+            currentEastMatchups = self.eastPicks[2];
+            currentMidwestMatchups = self.midwestPicks[2];
+            break;
+        case 3:
+            currentWestMatchups = self.westPicks[3];
+            currentSouthMatchups = self.southPicks[3];
+            currentEastMatchups = self.eastPicks[3];
+            currentMidwestMatchups = self.midwestPicks[3];
+            break;
+        case 4:
+            semisMatchups = self.finalsPicks[0];
+            break;
+        case 5:
+            championship = self.finalsPicks[1];
+            break;
+        default:
+            break;
+    }
     
     if (indexPath.section == 0) {
-        [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:self.westMatchups];
+        if (self.roundControl.selectedSegmentIndex < 4) {
+            [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:currentWestMatchups];
+        }
+        else if (self.roundControl.selectedSegmentIndex == 4){
+            [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:semisMatchups];
+        }
+        else{
+            [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:championship];
+        }
     }
     else if (indexPath.section == 1) {
-        [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:self.southMatchups];
+        [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:currentSouthMatchups];
     }
     else if (indexPath.section == 2) {
-        [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:self.eastMatchups];
+        [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:currentEastMatchups];
     }
-    else {
-        [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:self.midwestMatchups];
+    else if (indexPath.section == 3){
+        [self setBracketCells:createBracketViewCell atIndex:indexPath withArray:currentMidwestMatchups];
     }
-
     
     return createBracketViewCell;
 }
 
 - (void)setBracketCells:(CreateBracketViewCell *)cell atIndex:(NSIndexPath *) indexPath withArray:(NSMutableArray *) arr{
-    NSDictionary *game = arr[indexPath.row];
     cell.indexPath = indexPath.row;
-
-    cell.awayTeamName.text = self.teams[game[@"AwayTeam"]][@"School"];
-    NSURL *url = [NSURL URLWithString:self.teams[game[@"AwayTeam"]][@"TeamLogoUrl"]];
-    [cell.awayTeamLogo setImageWithURL:url];
+    cell.section = indexPath.section;
+    cell.createBracketView = self;
     
-    cell.homeTeamName.text = self.teams[game[@"HomeTeam"]][@"School"];
-    NSURL *url2 = [NSURL URLWithString:self.teams[game[@"HomeTeam"]][@"TeamLogoUrl"]];
-    [cell.homeTeamLogo setImageWithURL:url2];
     
-    if([game[@"HomeTeamMoneyLine"] intValue] < 0){
-        cell.homeFavorite.text = @"FAVORITE";
-        cell.awayFavorite.text = @"";
+    if (self.roundControl.selectedSegmentIndex == 0) {
+        NSDictionary *game = arr[indexPath.row];
+        
+        cell.awayTeamName.text = self.teams[game[@"AwayTeam"]][@"School"];
+        NSURL *url = [NSURL URLWithString:self.teams[game[@"AwayTeam"]][@"TeamLogoUrl"]];
+        [cell.awayTeamLogo setImageWithURL:url];
+        
+        cell.homeTeamName.text = self.teams[game[@"HomeTeam"]][@"School"];
+        NSURL *url2 = [NSURL URLWithString:self.teams[game[@"HomeTeam"]][@"TeamLogoUrl"]];
+        [cell.homeTeamLogo setImageWithURL:url2];
+        
+        if([game[@"HomeTeamMoneyLine"] intValue] < 0){
+            cell.homeFavorite.text = @"FAVORITE";
+            cell.awayFavorite.text = @"";
+        }
+        else{
+            cell.homeFavorite.text = @"";
+            cell.awayFavorite.text = @"FAVORITE";
+        }
     }
     else{
+        cell.awayTeamName.text = self.teams[arr[indexPath.row][0]][@"School"];
+        NSURL *url = [NSURL URLWithString:self.teams[arr[indexPath.row][0]][@"TeamLogoUrl"]];
+        [cell.awayTeamLogo setImageWithURL:url];
+        
+        cell.homeTeamName.text = self.teams[arr[indexPath.row][1]][@"School"];
+        NSURL *url2 = [NSURL URLWithString:self.teams[arr[indexPath.row][1]][@"TeamLogoUrl"]];
+        [cell.homeTeamLogo setImageWithURL:url2];
+        
+        //no odds for theoretical matchups so no favorites
+        cell.awayFavorite.text = @"";
         cell.homeFavorite.text = @"";
-        cell.awayFavorite.text = @"FAVORITE";
     }
+        
 
 }
 
+- (IBAction)roundSelectAction:(id)sender {
+    self.round = self.roundControl.selectedSegmentIndex;
+    
+    [self initializeUserBracket:self.westPicks];
+    [self initializeUserBracket:self.southPicks];
+    [self initializeUserBracket:self.eastPicks];
+    [self initializeUserBracket:self.midwestPicks];
+    [self initializeUserFinalsBracket:self.finalsPicks];
+
+    
+    self.user[@"westPicks"] = self.westPicks;
+    self.user[@"southPicks"] = self.southPicks;
+    self.user[@"eastPicks"] = self.eastPicks;
+    self.user[@"midwestPicks"] = self.midwestPicks;
+    self.user[@"finalsPicks"] = self.finalsPicks;
+    
+    [self.user saveInBackground];
+    [self.createBracketTableView reloadData];
+    
+}
 
 
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+   
+    switch (self.roundControl.selectedSegmentIndex) {
+        case 0:
+            return 8;
+            break;
+        case 1:
+            return 4;
+            break;
+        case 2:
+            return 2;
+            break;
+        case 3:
+            return 1;
+            break;
+        case 4:
+            return 2;
+            break;
+        default:
+            return 1;
+            break;
+    }
+    
     if (section == 0) {
         return self.westMatchups.count;
     }
@@ -151,13 +379,21 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
     else if (section == 2) {
         return self.eastMatchups.count;
     }
-    else {
+    else if (section == 3){
         return self.midwestMatchups.count;
+    }
+    else {
+        return self.finalsPicks.count;
     }
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView{
-    return 4;
+    if(self.round < 4){
+        return 4;
+    }
+    else{
+        return 1;
+    }
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section{
@@ -175,24 +411,136 @@ static NSString * const kMatchUpsEndpoint = @"https://api.sportsdata.io/v3/cbb/s
         header.textLabel.text = @"Midwest";
     }
     
+    if (self.roundControl.selectedSegmentIndex > 3) {
+        header.textLabel.text = @"";
+    }
+    
     header.textLabel.font = [header.textLabel.font fontWithSize:30];
     
     return header;
 }
 
+- (NSMutableArray *) initializeUserBracket:(NSMutableArray *) matchups {
+    NSMutableArray *round1 = matchups[0];
+    NSMutableArray *round2 = [[NSMutableArray alloc] init];
+    NSMutableArray *round3 = [[NSMutableArray alloc] init];
+    NSMutableArray *round4 = [[NSMutableArray alloc] init];
     
+    for (int i = 0; i < round1.count - 1; i+=2) {
+        NSArray *game = round1[i];
+        NSArray *game2 = round1[i+1];
 
+        NSString *winner1 = game[[game[2] intValue]];
+        NSString *winner2 = game2[[game2[2] intValue]];
+        if (matchups.count == 1) {
+            NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:winner1, winner2, @"0", nil];
+            [round2 addObject:matchup];
+        }
+        else{
+            NSString *choice = matchups[1][i/2][2];
+            NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:winner1, winner2, choice, nil];
+            [round2 addObject:matchup];
+        }
+       
+    }
+    for (int i = 0; i < round2.count - 1; i+=2) {
+        NSArray *game = round2[i];
+        NSArray *game2 = round2[i+1];
 
+        NSString *winner1 = game[[game[2] intValue]];
+        NSString *winner2 = game2[[game2[2] intValue]];
+        if (matchups.count == 1) {
+            NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:winner1, winner2, @"0", nil];
+            [round3 addObject:matchup];
+        }
+        else{
+            NSString *choice = matchups[2][i/2][2];
+            NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:winner1, winner2, choice, nil];
+            [round3 addObject:matchup];
+        }
+    }
+    for (int i = 0; i < round3.count - 1; i+=2) {
+        NSArray *game = round3[i];
+        NSArray *game2 = round3[i+1];
 
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
+        NSString *winner1 = game[[game[2] intValue]];
+        NSString *winner2 = game2[[game2[2] intValue]];
+        if (matchups.count == 1) {
+            NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:winner1, winner2, @"0", nil];
+            [round4 addObject:matchup];
+        }
+        else{
+            NSString *choice = matchups[3][i/2][2];
+            NSMutableArray *matchup = [[NSMutableArray alloc] initWithObjects:winner1, winner2, choice, nil];
+            [round4 addObject:matchup];
+        }
+    }
+    
+    matchups[1] = round2;
+    matchups[2] = round3;
+    matchups[3] = round4;
+    
+    return matchups;
 }
-*/
+- (NSMutableArray *) initializeUserFinalsBracket:(NSMutableArray *) finalsMatchups {
+    NSMutableArray *final_4 = [[NSMutableArray alloc] init];
+    NSMutableArray *championship = [[NSMutableArray alloc] init];
+    
+    //East vs West in final 4
+    NSArray *game = self.westPicks[3][0];
+    NSArray *game2 = self.eastPicks[3][0];
+    
+    NSString *winner1 = game[[game[2] intValue]];
+    NSString *winner2 = game2[[game2[2] intValue]];
+    
+    if (finalsMatchups.count == 0) {
+        NSMutableArray *EvWmatchup = [[NSMutableArray alloc] initWithObjects:winner1, winner2, @"0", nil];
+        [final_4 addObject:EvWmatchup];
+    }
+    else{
+        NSMutableArray *EvWmatchup = [[NSMutableArray alloc] initWithObjects:winner1, winner2, finalsMatchups[0][0][2], nil];
+        [final_4 addObject:EvWmatchup];
+    }
+    
+    //South vs Midwest in final 4
+    NSArray *game3 = self.southPicks[3][0];
+    NSArray *game4 = self.midwestPicks[3][0];
+    
+    NSString *winner3 = game3[[game3[2] intValue]];
+    NSString *winner4 = game4[[game4[2] intValue]];
+    
+    if (finalsMatchups.count == 0) {
+        NSMutableArray *SvMmatchup = [[NSMutableArray alloc] initWithObjects:winner3, winner4, @"0", nil];
+        [final_4 addObject:SvMmatchup];
+    }
+    else{
+        NSMutableArray *SvMmatchup = [[NSMutableArray alloc] initWithObjects:winner3, winner4, finalsMatchups[0][1][2], nil];
+        [final_4 addObject:SvMmatchup];
+    }
+    
+    //add final4 to finals matchups
+    finalsMatchups[0] = final_4;
+    
+    //championship
+    NSArray *semisGame1 = final_4[0];
+    NSArray *semisGame2 = final_4[1];
+    
+    NSString *finalist1 = semisGame1[[semisGame1[2] intValue]];
+    NSString *finalist2 = semisGame2[[semisGame2[2] intValue]];
+    
+    if (finalsMatchups.count == 1) {
+        NSMutableArray *finalMatchup = [[NSMutableArray alloc] initWithObjects:finalist1, finalist2, @"0", nil];
+        [championship addObject:finalMatchup];
+    }
+    else{
+        NSMutableArray *finalMatchup = [[NSMutableArray alloc] initWithObjects:finalist1, finalist2, finalsMatchups[1][0][2], nil];
+        [championship addObject:finalMatchup];
+    }
+    
+    finalsMatchups[1] = championship;
+
+    return finalsMatchups;
+}
 
 
 @end


### PR DESCRIPTION
User can now select teams to win both first round and future theoretical matchups.

- Matchups displayed in tableview cells in CreateBracketViewController, each cell shows a matchup
- Cells are separated by region into sections until final 4
- Each cell has a segmented controller with two options, one for each team, user can select who they predict will win a given match.
- Navbar contains segmented controller which indicates the round of the tournament.
- All selections are put into Parse.